### PR TITLE
Support running agent and client from source folders

### DIFF
--- a/iofog-agent-client/build.gradle
+++ b/iofog-agent-client/build.gradle
@@ -13,19 +13,8 @@ dependencies {
 	configurations.compile.extendsFrom(configurations.extraLibs)
 }
 
-task createProperties(dependsOn: processResources) {
-    doLast {
-        mkdir("$buildDir/resources/main")
-        new File("$buildDir/resources/main/version.properties").withWriter { w ->
-            Properties p = new Properties()
-            p['version'] = project.version.toString()
-            p.store w, null
-        }
-    }
-}
-
-classes {
-    dependsOn createProperties
+processResources {
+    expand(project.properties)
 }
 
 build {

--- a/iofog-agent-client/src/main/resources/version.properties
+++ b/iofog-agent-client/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${version}

--- a/iofog-agent-daemon/build.gradle
+++ b/iofog-agent-daemon/build.gradle
@@ -25,19 +25,8 @@ dependencies {
     testCompile 'org.powermock:powermock-core:2.0.2'
 }
 
-task createProperties(dependsOn: processResources) {
-    doLast {
-        mkdir("$buildDir/resources/main")
-        new File("$buildDir/resources/main/version.properties").withWriter { w ->
-            Properties p = new Properties()
-            p['version'] = project.version.toString()
-            p.store w, null
-        }
-    }
-}
-
-classes {
-    dependsOn createProperties
+processResources {
+    expand(project.properties)
 }
 
 build {

--- a/iofog-agent-daemon/src/main/resources/cmd_messages.properties
+++ b/iofog-agent-daemon/src/main/resources/cmd_messages.properties
@@ -1,9 +1,9 @@
-version_msg=ioFog %s \nCopyright (C) 2020 Edgeworx, Inc. \nEclipse ioFog is provided under the Eclipse Public License 2.0 (EPL-2.0) \nhttps://www.eclipse.org/legal/epl-v20.html
+version_msg=ioFog %s \\nCopyright (C) 2020 Edgeworx, Inc. \\nEclipse ioFog is provided under the Eclipse Public License 2.0 (EPL-2.0) \\nhttps://www.eclipse.org/legal/epl-v20.html
 deprovision_msg=Deprovisioning from controller ... %s
 provision_msg=Provisioning with key "%s" ... Result: %s
-provision_common_error=\nProvisioning failed
-provision_status_error=\nProvision failed with error message: "%s"
-provision_status_success=\nProvision success - Iofog UUID is %s
+provision_common_error=\\nProvisioning failed
+provision_status_error=\\nProvision failed with error message: "%s"
+provision_status_success=\\nProvision success - Iofog UUID is %s
 disk_consumption_limit=Message Storage Limit
 disk_directory=Message Storage Directory
 memory_consumption_limit=Memory RAM Limit

--- a/iofog-agent-daemon/src/main/resources/version.properties
+++ b/iofog-agent-daemon/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${version}


### PR DESCRIPTION
The version.properties file is now being created implicitly by Gradle's
processResources task. This makes it much easier to run the Agent and/or
Client from the compiled sources in an IDE.
