### PR TITLE
fix: secure processing of document transformation to prevent XSLT injection

### DIFF
--- a/iofog-agent-daemon/src/main/java/org/eclipse/iofog/utils/configuration/Configuration.java
+++ b/iofog-agent-daemon/src/main/java/org/eclipse/iofog/utils/configuration/Configuration.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -422,7 +423,18 @@ public final class Configuration {
     private static void updateConfigFile(String filePath, Document newFile) throws Exception {
         try {
             LoggingService.logInfo(MODULE_NAME, "Start updating configuration data to config.xml");
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            TransformerFactory secureFactory = TransformerFactory.newInstance();
+
+            try {
+                secureFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                secureFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                secureFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            Transformer transformer = secureFactory.newTransformer();
+
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             StreamResult result = new StreamResult(new File(filePath));
             DOMSource source = new DOMSource(newFile);
@@ -1092,6 +1104,15 @@ public final class Configuration {
 
         DOMSource source = new DOMSource(configFile);
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+        try {
+                transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (Exception e) {
+                throw new RuntimeException(e);
+        }
+        
         Transformer transformer = transformerFactory.newTransformer();
         StreamResult result = new StreamResult(getCurrentConfigPath());
         transformer.transform(source, result);


### PR DESCRIPTION
#### Motivation

In file: Configuration.java, there is a method updateConfigFile that transforms documents that come from an external source without proper validation and also there is a method createConfigProperty that transforms documents that come from an external source without proper validation. This may allow an attacker to execute malicious code or read sensitive file. To prevent/minimize the overall impact, when processing to any type of document secure processing should be enabled

```java
    secureFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
    secureFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
    secureFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
```

#### Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
